### PR TITLE
add option `*path-warning*` to missing dir in $PATH mount warnings

### DIFF
--- a/README.org
+++ b/README.org
@@ -49,6 +49,7 @@ Directories are mapped as /Unix FS packages/. A Unix FS packages is any Common L
 The exported symbols of a Unix FS package should one-to-one correspond to files in the mapped directory. Exceptions to this one-to-one correspondence:
 - Because of the limit of file system change tracking, the package structure in the Common Lisp image may diverge from the Unix FS state.
   - Currently, the state of a Unix FS package is synchronized when calling ~mount-directory~. By default, ~remount-current-directory~ is added to ~*post-command-hook*~, which does the obvious thing.
+  - If your environment's ~$PATH~ includes directories that do not exist, you will see warnings at every prompt like "~warning: Failed to mount /bad/path/ in $PATH: /bad/path/ does not exist.~" You'd benefit from fixing this where ~$PATH~ is defined (~.bashrc~, ~.profile~, ...), but can use ~(setf unix-in-lisp:*path-warning* nil)~ to silence the warnings instead.
 
 Each of these exported symbols has a global symbol macro binding, so that they can be read/write like Lisp variables. Access to the symbol gives the list of lines of the underlying file, and setting it with a list designator of lines cause them to be written to the file.
 

--- a/unix-in.lisp
+++ b/unix-in.lisp
@@ -19,7 +19,7 @@
 (named-readtables:in-readtable :standard)
 
 (defvar *post-command-hook* (make-instance 'nhooks:hook-void))
-(defvar *path-warning* 1
+(defvar *path-warning* t
   "Show warnings when a directory in $PATH cannot be mounted.")
 
 ;;; File system

--- a/unix-in.lisp
+++ b/unix-in.lisp
@@ -10,7 +10,7 @@
            #:cd #:exit
            #:process-status #:process-exit-code
            #:repl-connect #:*jobs* #:ensure-env-var #:synchronize-env-to-unix
-           #:*post-command-hook*))
+           #:*post-command-hook* #:*path-warning*))
 
 (uiop:define-package :unix-in-lisp.common)
 (uiop:define-package :unix-user)
@@ -19,6 +19,8 @@
 (named-readtables:in-readtable :standard)
 
 (defvar *post-command-hook* (make-instance 'nhooks:hook-void))
+(defvar *path-warning* 1
+  "Show warnings when a directory in $PATH cannot be mounted.")
 
 ;;; File system
 
@@ -1111,7 +1113,7 @@ symbol bindings."
   (let ((packages (iter (for path in (uiop:getenv-pathnames "PATH"))
                     (handler-case
                         (collect (mount-directory path))
-                      (file-error (c) (warn "Failed to mount ~A in $PATH: ~A" path c))))))
+                      (file-error (c) (when *path-warning* (warn "Failed to mount ~A in $PATH: ~A" path c)))))))
     (uiop:ensure-package :unix-in-lisp.path :mix packages :reexport packages)))
 
 (nhooks:add-hook *post-command-hook* 'ensure-path-package)


### PR DESCRIPTION
I'm sending this along in case it's useful, but please reject if not -- I'm still working on getting a grasp of what lisp code should look like.

My `$PATH` has accumulated a lot of detritus -- folders that were removed, never exist on this hosts, and folders that are now symlinks to a file. So the `post-command-hook` mount was spitting out a lot of warnings every prompt. This is my lazy solution. 

`*path-warning*` is a knob to toggle warnings that otherwise are seen before every prompt.

E.g.
> Failed to mount ... in $PATH: ... is a regular-file, wanted (directory).
> warning: Failed to mount /opt/afni/ in $PATH: /opt/afni/ does not exist.

A better fix is to maintain a hygienic `$PATH`. But after launching unix-in-lisp, it's maybe too late?

```
(setf (uiop:getenv "PATH") "/usr/bin") ; PATH remains unchanged?
```