### PR TITLE
bug setup: "~" is not a directory

### DIFF
--- a/unix-in.lisp
+++ b/unix-in.lisp
@@ -1184,7 +1184,7 @@ symbol bindings."
     (cl-advice:remove-advice :around 'sb-impl::%intern 'intern-hook))
   (values))
 
-(defun setup (&optional (path "~"))
+(defun setup (&optional (path (namestring (or (uiop/os:getcwd) (user-homedir-pathname)))))
   (ignore-some-conditions (already-installed) (install))
   (setq *package* (find-package :unix-user))
   (named-readtables:in-readtable unix-in-lisp)


### PR DESCRIPTION
I get "~" isn't a folder errors from
```
sbcl --eval '(ql:quickload "unix-in-lisp")' --eval '(unix-in-lisp:setup)' --eval '(fg (ls))'
```
like
> debugger invoked on a SIMPLE-ERROR in thread
> #<THREAD tid=645745 "main thread" RUNNING {1000BA0093}>:
>  Couldn't change directory to "~": No such file or directory



I updated `setup` to default to `(uiop/os:getcwd)` or `(user-homedir-pathname)`. The first seems more useful while the latter matches original "~" intent. But I'm not sure if either is reasonable.


Also sorry about the flurry of pull requests! This seems like a really interesting library; thanks for sharing!